### PR TITLE
Prioritise direct over peer dependencies

### DIFF
--- a/src/createConfig.js
+++ b/src/createConfig.js
@@ -124,9 +124,9 @@ const getDependencies = ({ cwd = process.cwd(), tsConfigPath } = {}) => {
     } = readPkgUp.sync({ cwd, normalize: true });
 
     const depsAsTuple = Object.entries({
+      ...peerDependencies,
       ...dependencies,
       ...devDependencies,
-      ...peerDependencies,
     });
 
     const deps = new Map(depsAsTuple);


### PR DESCRIPTION
I'm working on a React library and my `package.json` has something like:

```json
{
  "peerDependencies": {
    "react": ">=16"
  },
  "devDependencies": {
    "react": "^17.0.2"
  }
```

Currently, `eslint-config-galex` detects my React version as `>=16` instead of `^17.0.2`, which means that it enables the `react/react-in-jsx-scope` rule (among others) even though I use the `react-jsx` transform.

This fix makes sure that `devDependencies` and `dependencies` versions override any `peerDependencies` versions, as the latter are typically broader than the former.

---

Side note: `fulfillsVersionRequirement('>=17', { major: 17 })` returns `false`, but that's another issue (which I'll open now).