### PR TITLE
Use Jest's default test file globs

### DIFF
--- a/__tests__/overrides/__snapshots__/jest.test.ts.snap
+++ b/__tests__/overrides/__snapshots__/jest.test.ts.snap
@@ -99,7 +99,8 @@ exports[`createJestRules with create-react-app 1`] = `
     "plugin:jest-formatting/strict",
   ],
   "files": [
-    "**/*.?(test|spec).?(ts|js)?(x)",
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
   ],
   "globals": undefined,
   "overrideType": "eslint-config-galex/jest",
@@ -189,7 +190,8 @@ exports[`createJestRules with typescript 1`] = `
     "plugin:jest-formatting/strict",
   ],
   "files": [
-    "**/*.?(test|spec).?(ts|js)?(x)",
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
   ],
   "globals": undefined,
   "overrideType": "eslint-config-galex/jest",
@@ -411,7 +413,8 @@ exports[`override snapshots with jest-dom 1`] = `
     "plugin:jest-formatting/strict",
   ],
   "files": [
-    "**/*.?(test|spec).?(ts|js)?(x)",
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
   ],
   "globals": undefined,
   "overrideType": "eslint-config-galex/jest",
@@ -515,7 +518,8 @@ exports[`override snapshots with testing-lib 1`] = `
     "plugin:jest-formatting/strict",
   ],
   "files": [
-    "**/*.?(test|spec).?(ts|js)?(x)",
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
   ],
   "globals": undefined,
   "overrideType": "eslint-config-galex/jest",

--- a/src/overrides/jest.ts
+++ b/src/overrides/jest.ts
@@ -17,7 +17,7 @@ export const env: OverrideESLintConfig['env'] = {
 };
 
 export const extendsConfig = ['plugin:jest-formatting/strict'];
-export const files = ['**/*.?(test|spec).?(ts|js)?(x)'];
+export const files = ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'];
 export const parserOptions: OverrideESLintConfig['parserOptions'] = {
   ecmaVersion: 2020,
 };


### PR DESCRIPTION
The previous glob was not including files located inside a `__tests__` folder, and was also matching filenames such as `myFile..js`

https://jestjs.io/docs/27.x/configuration#testmatch-arraystring