### PR TITLE
Enable `es6` env

### DIFF
--- a/src/utils/defaultsAndDetection.ts
+++ b/src/utils/defaultsAndDetection.ts
@@ -40,6 +40,7 @@ export const detectEnv = (
   return {
     browser,
     node,
+    es6: true,
     ...customEnv,
   };
 };


### PR DESCRIPTION
This is needed for JS files and `no-undef`, notably for `Promise`, `Set`, etc.: https://github.com/eslint/eslint/issues/9812.

Not sure if the logic needs to be more complicated, perhaps with `!checkJs && enableJavaScriptSpecificRulesInTypeScriptProject`. Doesn't seem like it would hurt to enable it all the time, though.